### PR TITLE
Feature: Display tabs even if no active tab is present

### DIFF
--- a/lib/generators/tabs/templates/tabulous.rb
+++ b/lib/generators/tabs/templates/tabulous.rb
@@ -136,6 +136,11 @@ Tabulous.setup do |config|
   # an error is thrown.  If you turn this off, no error is thrown and the
   # tabs are simply not rendered.
   config.raise_error_if_no_tab_found = true
+  
+  # By default, when an action renders and no tab is defined for that action,
+  # the tabs are simply not rendered. If you turn this on, the tabs are
+  # still rendered, though no tab will be active.
+  render_tabs_if_no_tab_found = false
 
   # By default, div elements are used in the tab markup.  When html5 is
   # true, nav elements are used instead.

--- a/lib/tabulous/options.rb
+++ b/lib/tabulous/options.rb
@@ -28,6 +28,9 @@ module Tabulous
   mattr_accessor :raise_error_if_no_tab_found
   @@raise_error_if_no_tab_found = true
 
+  mattr_accessor :render_tabs_if_no_tab_found
+  @@render_tabs_if_no_tab_found = false
+
   mattr_accessor :css
   @@css = Css.new
 

--- a/lib/tabulous/tabulous.rb
+++ b/lib/tabulous/tabulous.rb
@@ -14,7 +14,7 @@ module Tabulous
 
   def self.render_tabs(view)
     initialize_tabs(view)
-    # return unless tab_defined?(view)
+    return unless tab_defined?(view) || @@render_tabs_if_no_tab_found
     html = ''
     html << embed_styles
     active_tab = active_tab(view)


### PR DESCRIPTION
The previous behavior was not to render the tabs at all if there was no tab defined for the current controller-action pair. I've stumbled on this in my current project where the tabs don't cover all of the possible controllers. Some of the controllers are reached from a drop-down in the navigation bar and there are no tabs for them. This led to the fact that as soon as the user clicked on a link in the drop-down and happened to be on a page for a controller not covered by the tabs, all of the navigation for the rest of the site (effectively rendered as tabs) was gone. Oops.

I've added an option to the Options class to augment the rendering behavior (render_tabs_if_no_tab_found) and changed the Tabulous class to treat it well.

By default, when an action renders and no tab is defined for that action, the tabs are simply not rendered. If you turn this on, the tabs are still rendered, though no tab will be active.
