### PR TITLE
Add :bootstrap_navbar to the default renderers in the comment section of tabulous.rb

### DIFF
--- a/lib/generators/tabs/templates/tabulous.rb
+++ b/lib/generators/tabs/templates/tabulous.rb
@@ -30,7 +30,7 @@ Tabulous.setup do
   customize do
 
     # which class to use to generate HTML
-    # :default, :html5, :bootstrap, or :bootstrap_pill
+    # :default, :html5, :bootstrap, :bootstrap_pill or :bootstrap_navbar
     # or create your own renderer class and reference it here
     # renderer :default
 


### PR DESCRIPTION
Although :bootstrap_navbar is listed in REFERENCE.md it doesn't appear in the comment section of tabulous.rb
