### PR TITLE
Fix detection of installed rails versions

### DIFF
--- a/script/create_test_app
+++ b/script/create_test_app
@@ -30,7 +30,7 @@ app_name = ARGV[0]
 rails_version = ARGV[1]
 
 installed_rails_versions = %x{ gem list rails }
-if installed_rails_versions =~ /rails\s\((.+)\)/
+if installed_rails_versions =~ /^rails\s\((.+)\)$/
   versions = $1.split(',').map(&:strip)
   if !versions.include?(rails_version)
     abort "Rails version '#{rails_version}' is not installed. First install this version of Rails before continuing."


### PR DESCRIPTION
The regular expression for finding the installed versions of rails used to match gems like readcrumbs_on_rails instead of rails.
Therefore the script was unable to determine the correct versions of rails and quitted.
